### PR TITLE
Don't set play=true for spring app.

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -123,7 +123,6 @@ export default class Builder {
       throw new Error('src/main/assets not found, are you in the right directory?');
     }
     
-    this.play = true;
     this.assetsRoot = './src/main/assets';
     this.outputPath = path.join(process.cwd(), 'build/resources/main/static/assets');
     this.publicPath = '/assets/';


### PR DESCRIPTION
play=true enables the fingerprinting plugin, which generates a bunch of copies of asset files. Spring doesn't need these, it calculates fingerprints on startup.