### PR TITLE
Add legacy Spring app support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /package-lock.json
 /dist
 node_modules/
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/webpack-config-builder",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Webpack configuration builder",
   "main": "dist/index.js",
   "dependencies": {

--- a/src/StaticHashesPlugin.js
+++ b/src/StaticHashesPlugin.js
@@ -1,0 +1,69 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable no-restricted-syntax */
+import {createHash} from 'crypto';
+import path from 'path';
+import slash from 'slash';
+
+/**
+ * Webpack plugin to hash all of the assets and write that hash to a single file.
+ */
+module.exports = class StaticHashesPlugin {
+  constructor({dest = 'WEB-INF/static-hashes.properties', base = false, hash = 'md5', delimiter = '=', maxLength = 12, salt = 'a'} = {}) {
+    this.options = {
+      dest,
+      base,
+      hash,
+      delimiter,
+      maxLength,
+      salt,
+    };
+  }
+
+  apply(compiler) {
+    compiler.hooks.emit.tapAsync('StaticHashesPlugin', (compilation, done) => {
+      const { assets } = compilation;
+      const { dest, hash, delimiter, maxLength, salt } = this.options;
+      const hashes = {};
+
+      const base = this.options.base || path.dirname(dest);
+
+      for (const filename in assets) {
+        if (Object.prototype.hasOwnProperty.call(assets, filename)) {
+          const filePath = path.relative(base, filename);
+
+          let fileHash =
+            createHash(hash)
+              .update(assets[filename].source(), 'binary')
+              .update(salt)
+              .digest('hex');
+
+          fileHash = parseInt(fileHash, 16);
+          if (fileHash < 0) fileHash = -fileHash;
+
+          fileHash = fileHash.toPrecision(21).replace(/[^\d]/g, '');
+          if (maxLength && fileHash.length > maxLength) {
+            fileHash = fileHash.substring(0, maxLength);
+          }
+
+          hashes[slash(filePath)] = fileHash;
+
+          // Identical to original file but with hash before the extension
+          // Note $& refers to the whole match, not $0. Thanks, Perl
+          assets[filename.replace(/\.[^\.]+$/, `.${fileHash}$&`)] = assets[filename];
+        }
+      }
+
+      const lines = Object.keys(hashes).sort().map((key) => `${key}${delimiter}${hashes[key]}\n`);
+      const contents = lines.join('');
+
+      const data = new Buffer(contents);
+
+      assets[dest] = {
+        source: () => data,
+        size: () => data.length,
+      };
+
+      done();
+    });
+  }
+};


### PR DESCRIPTION
This deprecates `.springApp()` in preference for `.springBootApp()` and adds a new `.configure({ assetsRoot, outputPath, publicPath })` for custom implementations. This also pulls in `StaticHashesPlugin` for non-Play projects (this is a little wasteful for Spring Boot apps, but shouldn't cause any issues).

Finally, a new `.copyAssets(paths)` method, broadly analogous to the two entry point methods `jsEntries()` and `cssEntries()` has been added to arbitrarily copy asset directories into the output path.